### PR TITLE
Site(s) renamed to group(s).

### DIFF
--- a/lib/the86-client.rb
+++ b/lib/the86-client.rb
@@ -10,7 +10,7 @@
   can_be_hidden
   access_token
   user
-  site
+  group
   post
   conversation
   like
@@ -21,17 +21,17 @@ module The86
 
     # API entry points.
 
-    def self.sites
+    def self.groups
       ResourceCollection.new(
         Connection.new,
-        "sites",
-        Site,
+        "groups",
+        Group,
         nil
       )
     end
 
-    def self.site(slug)
-      Site.new(slug: slug)
+    def self.group(slug)
+      Group.new(slug: slug)
     end
 
     def self.users

--- a/lib/the86-client/can_be_hidden.rb
+++ b/lib/the86-client/can_be_hidden.rb
@@ -13,7 +13,7 @@ module The86::Client
 
     def set_hidden(hidden, attributes)
       self.oauth_token = attributes[:oauth_token]
-      key = oauth_token ? :hidden_by_user : :hidden_by_site
+      key = oauth_token ? :hidden_by_user : :hidden_by_group
       patch(key => hidden)
     end
 

--- a/lib/the86-client/conversation.rb
+++ b/lib/the86-client/conversation.rb
@@ -8,7 +8,7 @@ module The86::Client
     attribute :updated_at, DateTime
 
     path "conversations"
-    belongs_to :site
+    belongs_to :group
     has_many :posts, ->{ Post }
 
     include CanBeHidden

--- a/lib/the86-client/group.rb
+++ b/lib/the86-client/group.rb
@@ -1,5 +1,5 @@
 module The86::Client
-  class Site < Resource
+  class Group < Resource
 
     attribute :id, Integer
     attribute :name, String
@@ -7,7 +7,7 @@ module The86::Client
     attribute :created_at, DateTime
     attribute :updated_at, DateTime
 
-    path "sites"
+    path "groups"
     has_many :conversations, ->{ Conversation }
 
     def url_id

--- a/lib/the86-client/resource.rb
+++ b/lib/the86-client/resource.rb
@@ -23,7 +23,7 @@ module The86
         end
 
         # The name of the parent resource attribute.
-        # e.g: belongs_to :site
+        # e.g: belongs_to :group
         def belongs_to(name)
           alias_method "#{name}=", :parent=
           alias_method name, :parent

--- a/lib/the86-client/resource_collection.rb
+++ b/lib/the86-client/resource_collection.rb
@@ -60,7 +60,7 @@ module The86::Client
     end
 
     # Load the next page of records, based on the pagination header, e.g.
-    # Link: <http://example.org/api/v1/sites/a/conversations?bumped_before=time>; rel="next"
+    # Link: <http://example.org/api/v1/groups/a/conversations?bumped_before=time>; rel="next"
     def more
       if more?
         url = Addressable::URI.parse(http_response.links[:next])

--- a/spec/likes_spec.rb
+++ b/spec/likes_spec.rb
@@ -4,10 +4,10 @@ module The86::Client
 
   describe Like do
 
-    let(:site) { The86::Client.site("test") }
-    let(:site_url) { "https://example.org/api/v1/sites/test" }
-    let(:post) { site.conversations.build(id: 1).posts.build(id: 2) }
-    let(:likes_url) { "#{site_url}/conversations/1/posts/2/likes" }
+    let(:group) { The86::Client.group("test") }
+    let(:group_url) { "https://example.org/api/v1/groups/test" }
+    let(:post) { group.conversations.build(id: 1).posts.build(id: 2) }
+    let(:likes_url) { "#{group_url}/conversations/1/posts/2/likes" }
 
     it "POSTs a new Like" do
       expect_request(

--- a/spec/posts_spec.rb
+++ b/spec/posts_spec.rb
@@ -4,13 +4,13 @@ module The86::Client
 
   describe Post do
 
-    let(:site) { The86::Client.site("test") }
-    let(:conversation) { Conversation.new(id: 32, site: site) }
+    let(:group) { The86::Client.group("test") }
+    let(:conversation) { Conversation.new(id: 32, group: group) }
     let(:original_post) do
       Post.new(id: 64, conversation: conversation, content: "Hello!")
     end
-    let(:site_url) { "https://example.org/api/v1/sites/test" }
-    let(:conversation_url) { "#{site_url}/conversations/32" }
+    let(:group_url) { "https://example.org/api/v1/groups/test" }
+    let(:conversation_url) { "#{group_url}/conversations/32" }
     let(:posts_url) { "#{conversation_url}/posts" }
 
     describe "replying to a post" do
@@ -79,11 +79,11 @@ module The86::Client
         }
       end
       describe "without oauth" do
-        it "patches the post as hidden_by_site when no oauth_token" do
-          expect_request(expectation(basic_auth_url, hidden_by_site: true))
+        it "patches the post as hidden_by_group when no oauth_token" do
+          expect_request(expectation(basic_auth_url, hidden_by_group: true))
           post.hide
 
-          expect_request(expectation(basic_auth_url, hidden_by_site: false))
+          expect_request(expectation(basic_auth_url, hidden_by_group: false))
           post.unhide
         end
       end


### PR DESCRIPTION
**Note**: This is a backward incompatible change!

From this point onwards you must replace all calls or references to 'site' or
'sites' with 'group' or 'groups'.
