### PR TITLE
Serialize metadata

### DIFF
--- a/lib/the86-client/resource.rb
+++ b/lib/the86-client/resource.rb
@@ -104,11 +104,14 @@ module The86
       end
 
       def sendable_attributes
-        attributes.reject do |key, value|
+        sa = attributes.reject do |key, value|
           [:id, :created_at, :updated_at].include?(key) ||
             value.kind_of?(Resource) ||
             value.nil?
         end
+
+        sa[:metadata] = attributes[:metadata].as_json
+        sa
       end
 
       def ==(other)


### PR DESCRIPTION
metadata was being serialised to string `#<The86::Client::ResourceCollection:0x007f4b0e792c68`.